### PR TITLE
add extra quarto->latex examples

### DIFF
--- a/_extensions/jds/jds_template.tex
+++ b/_extensions/jds/jds_template.tex
@@ -1,5 +1,10 @@
 \documentclass[nonacm,anonymous,acmsmall,pdftex]{acmart}
 
+$tightlist.tex()$
+$tables.tex()$
+
+\usepackage{algorithm2e}
+
 \begin{document}
 \title{$title$}
 \begin{abstract}

--- a/example_submission.qmd
+++ b/example_submission.qmd
@@ -2,6 +2,7 @@
 title: "My wonderful paper"
 abstract: "Blah blah"
 format: jds-pdf
+bibliography: references.bib
 ---
 
 # Introduction
@@ -65,3 +66,33 @@ $N \gets n$\;
 }
 \end{algorithm}
 
+## Code listings
+
+::: {#lst-stata-code}
+
+``` {.stata filename="group-occupations.do"}
+/*use "occupation.dta", clear*/
+/* merged data occupation*/
+/* professional, manager, teacher, assprofclerk, svcsales, armforces,
+xefe, farmer, craftrademach, labourer, driver, notclass */
+
+gen farmer=0
+replace farmer=1 if occupn>6000 & occupn<7000
+```
+
+Example STATA script for merging multiple occupations into larger groups
+:::
+
+Another example
+
+``` {#lst-sql-matvec .sql lst-cap="Query"}
+SELECT E.k as k, sum(E.w * S.x) as y
+```
+
+@lst-sql-matvec shows a query that does...
+
+## References
+
+This is an in-line citation with brackets [@wickhamTidyData2014].
+
+This is an in-line citation without brackets @wickhamTidyData2014

--- a/example_submission.qmd
+++ b/example_submission.qmd
@@ -7,3 +7,61 @@ format: jds-pdf
 # Introduction
 
 This is my wonderful paper. It is about wonderful things.
+
+# Things that BREAK
+
+Things that BREAK without the pandoc partials... <https://quarto.org/docs/journals/templates.html#latex-partials>
+
+## tightlist
+
+Fixed by `$tightlist.tex()$`
+
+1.  **Data Collection:** discovering and obtaining datasets containing harmonisable data
+2.  **Source Specific Cleaning:** identifying and resolving issues specific to a data source and collection method
+3.  **Crossmap Transforms:** transforming each source dataset into a common measurement standard, including both the design or selection of mappings between source and target keys and the actual data manipulation.
+4.  **Data Merging:** merging each transformed data into a single analysis-ready dataset.
+
+## Table Placement
+
+- adding $tables.tex()$ fixed the longtable error
+- use `tbl-pos` to specific positioning
+
+```{r}
+#| label: tbl-iso-crosswalk
+#| tbl-cap: "Country code crosswalk"
+#| tbl-pos: H
+#| echo: false
+#| output: asis
+
+iso_codes <- tibble::tribble(
+  ~country, ~ISO2, ~ISO3, ~ISONumeric,
+  "Afghanistan", "AF", "AFG", "004",
+  "Andorra", "AD", "AND", "020"
+) |> as.data.frame()
+
+kableExtra::kbl(iso_codes)
+```
+
+## Algorithms
+
+- Added `\usepackage{algorithm2e}`
+
+\begin{algorithm}
+\caption{An algorithm with caption}\label{alg:two}
+\KwData{$n \geq 0$}
+\KwResult{$y = x^n$}
+$y \gets 1$\;
+$X \gets x$\;
+$N \gets n$\;
+\While{$N \neq 0$}{
+  \eIf{$N$ is even}{
+    $X \gets X \times X$\;
+    $N \gets \frac{N}{2}$;
+  }{\If{$N$ is odd}{
+      $y \gets y \times X$\;
+      $N \gets N - 1$\;
+    }
+  }
+}
+\end{algorithm}
+

--- a/references.bib
+++ b/references.bib
@@ -1,0 +1,15 @@
+@article{wickhamTidyData2014,
+	title        = {Tidy {{Data}}},
+	author       = {Wickham, Hadley},
+	volume       = 59,
+	number       = 10,
+	doi          = {10.18637/jss.v059.i10},
+	issn         = {1548-7660},
+	url          = {http://www.jstatsoft.org/v59/i10/},
+	urldate      = {2022-10-17},
+	date         = 2014,
+	journaltitle = {Journal of Statistical Software},
+	shortjournal = {J. Stat. Soft.},
+	langid       = {english},
+	file         = {/Users/chua0032/Zotero/storage/BN3V3V5L/tidy-data.pdf;/Users/cynthiahqy/Dropbox/Obsidian/Zotero/wickhamTidyData2014.md}
+}


### PR DESCRIPTION
Modifies the extension & template to:
- stop throwing errors relating to `tightlist`, `tables`
- use `algorithm2e` to support algorithm typesetting
- add BROKEN codelisting (#2 )
- add BROKEN in-line citations/references (#4 )